### PR TITLE
Expanding type structure and simplifying code

### DIFF
--- a/examples/example3.jl
+++ b/examples/example3.jl
@@ -8,9 +8,9 @@ factors = [:l, :k]
 
 factor = DenseAxisArray(Float64[50 50; 20 30], goods, factors)
 supply = DenseAxisArray(Float64[100, 50], goods)
-outtax = add!(m, Parameter(:outtax, indices=(goods,), value=0.))
-intax  = add!(m, Parameter(:intax,  indices=(goods,), value=0.))
-endow  = add!(m, Parameter(:endow,  indices=(factors,), value=1.0))
+outtax = add!(m, Parameter(:outtax, indices=(goods,), value=[0.,0.]))
+intax  = add!(m, Parameter(:intax,  indices=(goods,), value=[0.,0.]))
+endow  = add!(m, Parameter(:endow,  indices=(factors,), value=[1.,1.]))
 
 Y = add!(m, Sector(:Y, indices=(goods,)))
 U = add!(m, Sector(:U))

--- a/src/MPSGE.jl
+++ b/src/MPSGE.jl
@@ -11,6 +11,9 @@ export Sector, Commodity, Consumer, Aux, Production, DemandFunction, AuxConstrai
 export value, set_value, get_value, set_fixed!, get_nested_commodity, set_lower_bound, set_upper_bound
 export @parameter, @sector, @commodity, @consumer, @production, @demand
 
+include("structs/references.jl")
+include("structs/variables.jl")
+
 include("model.jl")
 include("macros.jl")
 include("build/build_helpers.jl")

--- a/src/algebraic_wrapper.jl
+++ b/src/algebraic_wrapper.jl
@@ -15,12 +15,12 @@ function algebraic_version(m::Model)
     return AlgebraicWrapper(
         m,
         jump_model,
-        sum(length(s.inputs) for s in m._productions),
-        sum(length(s.outputs) for s in m._productions),
-        sum(length(d.demands) for d in m._demands),
-        length(m._productions),
-        sum(c isa ScalarCommodity ? 1 : c isa IndexedCommodity ? prod(length.(c.indices)) : error("Invalid") for c in m._commodities),
-        length(m._demands)
+        sum(length(s.inputs) for s in productions(m)),
+        sum(length(s.outputs) for s in productions(m)),
+        sum(length(d.demands) for d in demands(m)),
+        length(productions(m)),
+        sum(c isa ScalarCommodity ? 1 : c isa IndexedCommodity ? prod(length.(c.indices)) : error("Invalid") for c in commodities(m)),
+        length(demands(m))
     )
 end
 

--- a/src/build/build_auxconstraints.jl
+++ b/src/build/build_auxconstraints.jl
@@ -1,6 +1,6 @@
 function build_auxconstraints!(m::Model, jm)
     # Add aux constraints
-    for ac in m._auxconstraints
+    for ac in auxconstraints(m)
         ac.equation isa Expr || error("You must pass an expression as an aux constraint.")
         (ac.equation.head == :call && length(ac.equation.args) == 3 && ac.equation.args[1] == :(==)) || error("Must pass an equation with an == sign.")
 

--- a/src/build/build_helpers.jl
+++ b/src/build/build_helpers.jl
@@ -40,11 +40,7 @@ This function takes an expression tree and replaces all instances of
 function swap_our_param_with_val(expr)
     return MacroTools.postwalk(expr) do x
         if x isa ParameterRef
-            if x.subindex===nothing
-                return x.model._parameters[x.index].value
-            else
-                return x.model._parameters[x.index].value[x.subindex]
-            end
+            return get_value(x)
         elseif x isa CommodityRef
             c = get_full(x)
             if c isa ScalarCommodity
@@ -105,9 +101,9 @@ end
 
 function get_jump_variable_for_param(jm, parameter::ParameterRef)
     if parameter.subindex===nothing
-        return jm[parameter.model._parameters[parameter.index].name]
+        return jm[get_name(parameter)]
     else
-        return jm[parameter.model._parameters[parameter.index].name][parameter.subindex]
+        return jm[get_name(parameter)][parameter.subindex]
     end
 end
 
@@ -182,7 +178,7 @@ end
 
 # function get_tax_revenue_for_consumer(jm, m, consumer::ScalarConsumer)
 #     taxes = []
-#     for pf in m._productions
+#     for pf in productions(m)
 #         for output in pf.outputs
 #             for tax in output.taxes
 #                 if get_full(tax.agent) == consumer
@@ -206,7 +202,7 @@ end
 
 function get_tax_revenue_for_consumer(jm, m, cr::ConsumerRef)
     taxes = []
-    for pf in m._productions
+    for pf in productions(m)
         for output in pf.outputs
             for tax in output.taxes
                 if cr.subindex === nothing
@@ -242,7 +238,7 @@ end
 
 function get_tax_revenue_for_consumer_old(jm, m, consumer::ScalarConsumer)
     taxes = []
-    for pf in m._productions
+    for pf in productions(m)
         for output in pf.outputs
             for tax in output.taxes
                 if get_full(tax.agent) == consumer
@@ -266,7 +262,7 @@ end
 
 function get_tax_revenue_for_consumer_old(jm, m, cr::ConsumerRef)
     taxes = []
-    for pf in m._productions
+    for pf in productions(m)
         for output in pf.outputs
             for tax in output.taxes
                 if cr.subindex === nothing

--- a/src/build/build_implicitconstraints.jl
+++ b/src/build/build_implicitconstraints.jl
@@ -199,7 +199,7 @@ end
 
 function build_implicitconstraints!(m, jm)
     # Add compensated demand (intermediate and factor)
-    for s in m._productions
+    for s in productions(m)
         for input in s.inputs
 
             jump_ex = 
@@ -221,7 +221,7 @@ function build_implicitconstraints!(m, jm)
     end
 
     # Add compensated supply
-    for s in m._productions
+    for s in productions(m)
         for output in s.outputs
             jump_ex =
                 tojump(jm, output.quantity) *
@@ -244,7 +244,7 @@ function build_implicitconstraints!(m, jm)
     end
 
     # Add final demand
-    for demand_function in m._demands
+    for demand_function in demands(m)
             for demand in demand_function.demands
                 jump_ex = tojump(jm, demand.quantity) *
                     (

--- a/src/build/build_incomebalance.jl
+++ b/src/build/build_incomebalance.jl
@@ -1,6 +1,6 @@
 function build_incomebalance!(m, jm)
     # Add income balance constraints
-    for c in m._demands
+    for c in demands(m)
         jump_ex = +(
                 (tojump(jm, en.quantity) * tojump(jm, en.commodity) for en in c.endowments)...
             ) +

--- a/src/build/build_marketclearance.jl
+++ b/src/build/build_marketclearance.jl
@@ -2,7 +2,7 @@ function build_marketclearance!(m, jm)
     # Add market clearance constraints
 
     commodities = Set{CommodityRef}()
-    for pf in m._productions
+    for pf in productions(m)
         for input in pf.inputs
             push!(commodities, input.commodity)
         end
@@ -11,7 +11,7 @@ function build_marketclearance!(m, jm)
             push!(commodities, output.commodity)
         end
     end
-    for df in m._demands
+    for df in demands(m)
         for demand in df.demands
             push!(commodities, demand.commodity)
         end
@@ -22,7 +22,7 @@ function build_marketclearance!(m, jm)
     for commodity in commodities
         # Find all endowments for current commodity
         endows = []
-        for demand_function in m._demands
+        for demand_function in demands(m)
             for en in demand_function.endowments
                 if en.commodity==commodity
                     push!(endows, tojump(jm, en.quantity))
@@ -32,7 +32,7 @@ function build_marketclearance!(m, jm)
 
         # Find all intermediate supplies for current commodity
         comp_supplies = []
-        for production_function in m._productions
+        for production_function in productions(m)
             for output in production_function.outputs
                 if output.commodity==commodity
                     push!(comp_supplies, tojump(jm, production_function.sector) * tojump(jm, m._implicitvarsDict[get_comp_supply_name(output)]))
@@ -42,7 +42,7 @@ function build_marketclearance!(m, jm)
 
         # Find all final demand for current commodity
         final_demand = []
-        for demand_function in m._demands
+        for demand_function in demands(m)
             for demand in demand_function.demands
                 if demand.commodity == commodity
                     push!(final_demand, tojump(jm, m._implicitvarsDict[get_final_demand_name(demand)]))
@@ -52,7 +52,7 @@ function build_marketclearance!(m, jm)
 
         # Find all the intermediate demands for current commodity
         comp_demands = []
-        for production_function in m._productions
+        for production_function in productions(m)
             for input in production_function.inputs
                 if input.commodity==commodity
                     push!(comp_demands, tojump(jm, production_function.sector) * tojump(jm, m._implicitvarsDict[get_comp_demand_name(input)]))

--- a/src/build/build_startvalues_bounds.jl
+++ b/src/build/build_startvalues_bounds.jl
@@ -1,6 +1,6 @@
 function set_all_start_values(m)
     jm = m._jump_model
-    for s in m._sectors
+    for s in sectors(m)
         if s isa ScalarSector
             JuMP.set_start_value(jm[s.name], s.benchmark)
         else
@@ -10,7 +10,7 @@ function set_all_start_values(m)
         end
     end
 
-    for c in m._commodities
+    for c in commodities(m)
         if c isa ScalarCommodity
             JuMP.set_start_value(jm[c.name], c.benchmark)
         else
@@ -20,14 +20,14 @@ function set_all_start_values(m)
         end
     end
 
-    for s in m._productions
+    for s in productions(m)
         for i in s.inputs
             compensated_input1_demand_name = get_comp_demand_name(i)
             JuMP.set_start_value(jm[compensated_input1_demand_name], eval(swap_our_param_with_val(i.quantity)))
         end
     end
 
-    for c in m._consumers
+    for c in consumers(m)
         if c isa ScalarConsumer
             if c.fixed
                 start_val = c.benchmark
@@ -47,7 +47,7 @@ function set_all_start_values(m)
         end
     end
 
-    for aux in m._auxs
+    for aux in auxs(m)
         if aux isa ScalarAux
             JuMP.set_start_value(jm[aux.name], aux.benchmark)
         else
@@ -58,14 +58,14 @@ function set_all_start_values(m)
     end
 
     # Add compensated supply variables
-    for s in m._productions
+    for s in productions(m)
         for o in s.outputs
             JuMP.set_start_value(jm[get_comp_supply_name(o)], eval(swap_our_param_with_val(o.quantity)))
         end
     end
 
     # Add final demand variables
-    for demand_function in m._demands
+    for demand_function in demands(m)
         for demand in demand_function.demands
             JuMP.set_start_value(jm[get_final_demand_name(demand)], eval(swap_our_param_with_val(demand.quantity)))
         end
@@ -75,7 +75,7 @@ end
 function set_all_bounds(m)
     jm = m._jump_model
 
-    for c in m._commodities
+    for c in commodities(m)
         if c isa ScalarCommodity
             jump_var = jm[c.name]
 # TODONE: Allow user defined lower and upper bounds with defaults
@@ -106,7 +106,7 @@ function set_all_bounds(m)
         end
     
     end
-    for cs in m._consumers
+    for cs in consumers(m)
         if cs isa ScalarConsumer
             jump_var = jm[cs.name]
             if cs.fixed
@@ -136,7 +136,7 @@ function set_all_bounds(m)
         end
     end
 
-    for a in m._auxs
+    for a in auxs(m)
         if a isa ScalarAux
             jump_var = jm[a.name]
 # TODONE: Allow user defined llower and upper bounds with defaults
@@ -169,7 +169,7 @@ function set_all_bounds(m)
     
     end
 
-    for s in m._sectors
+    for s in sectors(m)
         if s isa ScalarSector
             jump_var = jm[s.name]
 # TODONE: Allow user defined llower and upper bounds with defaults
@@ -207,7 +207,7 @@ end
 function set_all_parameters(m)
     jm = m._jump_model
 
-    for p in m._parameters
+    for p in parameters(m)
         if p isa ScalarParameter
             JuMP.set_parameter_value(jm[p.name], p.value)
         else

--- a/src/build/build_variables.jl
+++ b/src/build/build_variables.jl
@@ -78,19 +78,19 @@ end
 
 function add_implicitvars!(m)
     # Add compensated supply variable Refs to model
-    for s in m._productions
+    for s in productions(m)
         for o in s.outputs
             add!(m, Implicitvar(get_comp_supply_name(o), typeof(o)))
         end
     end
     # Add compensated demand variables
-    for s in m._productions
+    for s in productions(m)
         for i in s.inputs
             add!(m, Implicitvar(get_comp_demand_name(i), typeof(i)))
         end
     end
    # Add final demand variables
-   for demand_function in m._demands
+   for demand_function in demands(m)
         for demand in demand_function.demands
             add!(m, Implicitvar(get_final_demand_name(demand), typeof(demand)))
         end
@@ -100,45 +100,45 @@ end
 function build_variables!(m, jm)
     # Add all parameters
 
-    for p in m._parameters
+    for p in parameters(m)
         add_parameter_to_jump!(jm, p)
     end
 
     # Add all required variables
 
-    for s in m._sectors
+    for s in sectors(m)
         add_sector_to_jump!(jm, s)        
     end
 
-    for c in m._commodities
+    for c in commodities(m)
         add_commodity_to_jump!(jm, c)
     end
 
     # Add aux variables
-    for aux in m._auxs
+    for aux in auxs(m)
         add_aux_to_jump!(jm, aux)
     end
 
     # Add compensated supply variables
-    for s in m._productions
+    for s in productions(m)
         for o in s.outputs
             add_variable!(jm, get_comp_supply_name(o))
         end
     end
 
     # Add compensated demand variables
-    for s in m._productions
+    for s in productions(m)
         for i in s.inputs
             add_variable!(jm, get_comp_demand_name(i))
         end
     end
 
-    for c in m._consumers
+    for c in consumers(m)
         add_consumer_to_jump!(jm, c)
     end
 
     # Add final demand variables
-    for demand_function in m._demands
+    for demand_function in demands(m)
         for demand in demand_function.demands
             add_variable!(jm, get_final_demand_name(demand))
         end

--- a/src/build/build_zeroprofit.jl
+++ b/src/build/build_zeroprofit.jl
@@ -1,7 +1,7 @@
 function build_zeroprofit!(m, jm)
 
     # Add zero profit constraints
-    for s in m._productions
+    for s in productions(m)
         jump_ex =+(
                 (
                     get_expression_for_commodity_consumer_price(jm, s, input.commodity) * tojump(jm, m._implicitvarsDict[get_comp_demand_name(input)]) for input in s.inputs

--- a/src/model.jl
+++ b/src/model.jl
@@ -198,21 +198,11 @@ function get_name(im::ImplicitvarRef, include_subindex=false)
     # end 
 end
 
-function get_full(s::SectorRef)
-    return s.model._sectors[s.index]
+
+function get_full(s::MPSGERef)
+    return s.model[s.name]
 end
 
-function get_full(c::CommodityRef)
-    return c.model._commodities[c.index]
-end
-
-function get_full(c::ConsumerRef)
-    return c.model._consumers[c.index]
-end
-
-function get_full(a::AuxRef)
-    return a.model._auxs[a.index]
-end
 
 function get_full(p::ParameterRef)
     return p.model._parameters[p.index]

--- a/src/model.jl
+++ b/src/model.jl
@@ -637,3 +637,18 @@ function set_upper_bound(V::MPSGERef, u_bound::Float64)
     _set_upper_bound(var,V, u_bound)
 end
 
+#############################
+## Extracting Model Fields ##
+#############################
+parameters(m::model) = m._parameters
+sectors(m::Model) = m._sectors
+commodities(m::Model) = m._commodities
+consumers(m::Model) = m._consumers
+auxs(m::Model) = m._auxs
+implicitvars(m::Model) = m._implicitvars
+implicitvarsDict(m::Model) = m._implicitvarsDict
+
+productions(m::Model) = m._productions
+demands(m::Model) = m._demands
+auxconstraints(m::Model) = m._auxconstraints
+

--- a/src/model.jl
+++ b/src/model.jl
@@ -365,7 +365,7 @@ function _add!(m::Model,s::MPSGEScalar,output_type,model_array)
     m._jump_model = nothing
     push!(model_array, s)
 
-    s_ref = output_type(m, length(model_array), nothing, nothing)
+    s_ref = output_type(m, length(model_array), s.name,nothing, nothing)
     m._object_dict[s.name] = s
 
     return s_ref
@@ -379,7 +379,7 @@ function _add!(m::Model,s::MPSGEIndexed,output_type, model_array)
     temp_array = Array{output_type}(undef, length.(s.indices)...)
 
     for i in CartesianIndices(temp_array)
-        temp_array[i] = output_type(m, length(model_array), i, Tuple(s.indices[j][v] for (j,v) in enumerate(Tuple(i))))
+        temp_array[i] = output_type(m, length(model_array), s.name, i, Tuple(s.indices[j][v] for (j,v) in enumerate(Tuple(i))))
     end
 
     return JuMP.Containers.DenseAxisArray(temp_array, s.indices...)
@@ -491,7 +491,7 @@ end
 function add!(m::Model, p::ScalarParameter)
     m._jump_model = nothing
     push!(m._parameters, p)
-    return ParameterRef(m, length(m._parameters), nothing, nothing)
+    return ParameterRef(m, length(m._parameters),p.name, nothing, nothing)
 end
 
 function add!(m::Model, p::IndexedParameter)
@@ -501,7 +501,7 @@ function add!(m::Model, p::IndexedParameter)
     temp_array = Array{ParameterRef}(undef, length.(p.indices)...)
 
     for i in CartesianIndices(temp_array)
-        temp_array[i] = ParameterRef(m, length(m._parameters), i, Tuple(p.indices[j][v] for (j,v) in enumerate(Tuple(i))))
+        temp_array[i] = ParameterRef(m, length(m._parameters),  p.name,i, Tuple(p.indices[j][v] for (j,v) in enumerate(Tuple(i))))
     end
     return JuMP.Containers.DenseAxisArray(temp_array, p.indices...)
 end

--- a/src/model.jl
+++ b/src/model.jl
@@ -326,8 +326,8 @@ end
 function _add!(m::Model,s::MPSGEScalar,output_type,model_array)
     m._jump_model = nothing
     push!(model_array, s)
-
     s_ref = output_type(m, length(model_array), s.name,nothing, nothing)
+    @assert s.name ∉ keys(m._object_dict) "Variable $(s.name) already associated with model"
     m._object_dict[s.name] = s
 
     return s_ref

--- a/src/model.jl
+++ b/src/model.jl
@@ -1,233 +1,4 @@
-struct ParameterRef
-    model
-    index::Int
-    subindex::Any
-    subindex_names::Any
-end
 
-struct SectorRef
-    model
-    index::Int
-    subindex::Any
-    subindex_names::Any
-end
-
-struct CommodityRef
-    model
-    index::Int
-    subindex::Any
-    subindex_names::Any
-end
-
-struct ConsumerRef
-    model
-    index::Int
-    subindex::Any
-    subindex_names::Any
-end
-
-struct AuxRef
-    model
-    index::Int
-    subindex::Any
-    subindex_names::Any
-end
-
-struct ImplicitvarRef
-    model
-    index::Int
-    subindex::Any
-    subindex_names::Any
-end
-
-"""
-    Parameter(:symbol; indices, value::Float64=1., string)
-    Struct that holds the name, indices if IndexedParameter, value, and optional description of a parameter within the model.
-### Options
-    Parameter::ScalarParameter, IndexedParameter
-### Example
-```julia-repl
-julia> P = add!(Parameter(model, :P, value=1., description="Elasticity"))
-julia> sectors = [:s1, :s2]
-julia> P = add!(Parameter(model, :P, indices=(,sectors), value=1., description="Elasticity parameters for X Sector "))
-```
-"""
-abstract type Parameter end;
-
-mutable struct ScalarParameter <: Parameter
-    name::Symbol
-    value::Float64
-    description::String
-
-    function ScalarParameter(name::Symbol; value::Float64=1., description::AbstractString="")
-        return new(name, value, description)
-    end
-end
-
-mutable struct IndexedParameter <: Parameter
-    name::Symbol
-    indices::Any
-    value::DenseAxisArray
-    description::String
-
-    function IndexedParameter(name::Symbol, indices; value::Union{Array{Float64},Array{Int}}, description::AbstractString="")
-            return new(name, indices, DenseAxisArray(Float64.(value), indices...), description)
-
-    end
-end
-
-function Parameter(name; indices=nothing, kwargs...)
-    return indices===nothing ? ScalarParameter(name; kwargs...) : IndexedParameter(name, indices; kwargs...)
-end
-
-abstract type Sector end;
-
-mutable struct ScalarSector <: Sector
-    name::Symbol
-    benchmark::Float64
-    lower_bound::Float64
-    upper_bound::Float64
-    description::String
-    fixed::Bool
-
-    function ScalarSector(name::Symbol; description::AbstractString="", lower_bound::Float64=0.0, upper_bound=10e100, benchmark::Float64=1., fixed=false)
-        return new(name, benchmark, lower_bound, upper_bound, description, fixed)
-    end
-end
-
-mutable struct IndexedSector <: Sector
-    name::Symbol
-    indices::Any
-    benchmark::DenseAxisArray
-    lower_bound::DenseAxisArray
-    upper_bound::DenseAxisArray
-    description::String
-    fixed::DenseAxisArray
-
-    function IndexedSector(name::Symbol, indices; benchmark::Float64=1., lower_bound::Float64=0.0, upper_bound::Float64=10e100, description::AbstractString="",  fixed=false)
-        return new(name, indices, DenseAxisArray(fill(benchmark, length.(indices)...), indices...), DenseAxisArray(fill(lower_bound, length.(indices)...), indices...), DenseAxisArray(fill(upper_bound, length.(indices)...), indices...), description, DenseAxisArray(fill(fixed, length.(indices)...), indices...))
-    end
-end
-
-"""
-    Sector(:symbol; indices, value::Float64=1., string)
-    Struct that holds the name, (indices if IndexedSector), value, and optional description of a sector within the model.
-### Options
-    Sector::ScalarSector, IndexedSector
-### Example
-```julia-repl
-julia> S = add!(Sector(model, :S, value=1., description="Sector S"))
-julia> sectors = [:s1, :s2]
-julia> P = add!(Sector(model, :S, indices=(,sectors), value=1., description="S[:s1] and S[:s2] Sectors"))
-```
-"""
-function Sector(name; indices=nothing, kwargs...)
-    return indices===nothing ? ScalarSector(name; kwargs...) : IndexedSector(name, indices; kwargs...)
-end
-
-abstract type Commodity end;
-
-mutable struct ScalarCommodity <: Commodity
-    name::Symbol
-    benchmark::Float64
-    lower_bound::Float64
-    upper_bound::Float64
-    description::String
-    fixed::Bool
-
-    function ScalarCommodity(name::Symbol; description::AbstractString="", lower_bound::Float64=0.001, upper_bound::Float64=10e100, benchmark::Float64=1., fixed=false)
-        return new(name, benchmark, lower_bound, upper_bound, description, fixed)
-    end
-end
-
-mutable struct IndexedCommodity <: Commodity
-    name::Symbol
-    indices::Any
-    benchmark::DenseAxisArray
-    lower_bound::DenseAxisArray
-    upper_bound::DenseAxisArray
-    description::String
-    fixed::DenseAxisArray
-
-    function IndexedCommodity(name::Symbol, indices; benchmark::Float64=1., lower_bound::Float64=0.001, upper_bound::Float64=10e100, description::AbstractString="", fixed=false)
-        return new(name, indices, DenseAxisArray(fill(benchmark, length.(indices)...), indices...), DenseAxisArray(fill(lower_bound, length.(indices)...), indices...), DenseAxisArray(fill(upper_bound, length.(indices)...), indices...), description, DenseAxisArray(fill(fixed, length.(indices)...), indices...))
-    end
-end
-
-function Commodity(name; indices=nothing, kwargs...)
-    return indices===nothing ? ScalarCommodity(name; kwargs...) : IndexedCommodity(name, indices; kwargs...)
-end
-
-abstract type Consumer end;
-
-mutable struct ScalarConsumer <: Consumer
-    name::Symbol
-    benchmark::Float64
-    lower_bound::Float64
-    upper_bound::Float64
-    description::String
-    fixed::Bool
-    
-    function ScalarConsumer(name::Symbol; description::AbstractString="", lower_bound::Float64=0.0, upper_bound::Float64=10e100, benchmark::Float64=1., fixed=false)
-        return new(name, benchmark, lower_bound, upper_bound, description, fixed)
-    end
-end
-
-mutable struct IndexedConsumer <: Consumer
-    name::Symbol
-    indices::Any
-    benchmark::DenseAxisArray
-    lower_bound::DenseAxisArray
-    upper_bound::DenseAxisArray
-    description::String
-    fixed::DenseAxisArray
-
-    function IndexedConsumer(name::Symbol, indices; benchmark::Float64=1., lower_bound::Float64=0.0, upper_bound::Float64=10e100, description::AbstractString="", fixed=false)
-        return new(name, indices, DenseAxisArray(fill(benchmark, length.(indices)...), indices...), DenseAxisArray(fill(lower_bound, length.(indices)...), indices...), DenseAxisArray(fill(upper_bound, length.(indices)...), indices...), description, DenseAxisArray(fill(fixed, length.(indices)...), indices...))
-    end
-end
-
-function Consumer(name; indices=nothing, kwargs...)
-    return indices===nothing ? ScalarConsumer(name; kwargs...) : IndexedConsumer(name, indices; kwargs...)
-end
-
-abstract type Aux end;
-
-mutable struct ScalarAux <: Aux
-    name::Symbol
-    benchmark::Float64
-    lower_bound::Float64
-    upper_bound::Float64
-    description::String
-    fixed::Bool
-
-    function ScalarAux(name::Symbol; description::AbstractString="", lower_bound::Float64=0.0, upper_bound::Float64=10e100, benchmark::Float64=1., fixed=false)
-        return new(name, benchmark, lower_bound, upper_bound, description, fixed)
-    end
-end
-
-mutable struct IndexedAux <: Aux
-    name::Symbol
-    indices::Any
-    benchmark::DenseAxisArray
-    lower_bound::DenseAxisArray
-    upper_bound::DenseAxisArray
-    description::String
-    fixed::DenseAxisArray
-
-    function IndexedAux(name::Symbol, indices; benchmark::Float64=1., lower_bound::Float64=0.0, upper_bound::Float64=10e100, description::AbstractString="", fixed=false)
-        return new(name, indices, DenseAxisArray(fill(benchmark, length.(indices)...), indices...), DenseAxisArray(fill(lower_bound, length.(indices)...), indices...), DenseAxisArray(fill(upper_bound, length.(indices)...), indices...), description, DenseAxisArray(fill(fixed, length.(indices)...), indices...))
-    end
-end
-
-function Aux(name; indices=nothing, kwargs...)
-    return indices===nothing ? ScalarAux(name; kwargs...) : IndexedAux(name, indices; kwargs...)
-end
-
-struct Tax
-    rate::Union{Float64,Expr}
-    agent::ConsumerRef
-end
 
 """
    Input(inputname::Symbol, value::Float64; taxes=taxes::Vector{Tax}, price=price::Union{Float64,Expr}=1.)
@@ -357,11 +128,13 @@ julia> foo = Model()
 ```
 """
 mutable struct Model
+    _object_dict::Dict
+
     _parameters::Vector{Parameter}
-    _sectors::Vector{Sector}
-    _commodities::Vector{Commodity}
-    _consumers::Vector{Consumer}
-    _auxs::Vector{Aux}
+    _sectors::Vector{Union{ScalarSector,IndexedSector}}
+    _commodities::Vector{Union{ScalarCommodity,IndexedCommodity}}
+    _consumers::Vector{Union{ScalarConsumer,IndexedConsumer}}
+    _auxs::Vector{Union{ScalarAux,IndexedAux}}
     _implicitvars::Vector{Implicitvar}
     _implicitvarsDict::Dict{Symbol, ImplicitvarRef}
 
@@ -376,11 +149,12 @@ mutable struct Model
 
     function Model()
         return new(
+            Dict(),
             Parameter[],
-            Sector[],
-            Commodity[],
-            Consumer[],
-            Aux[],
+            Vector{Union{ScalarSector,IndexedSector}}(),
+            Vector{Union{ScalarCommodity,IndexedCommodity}}(),
+            Vector{Union{ScalarConsumer,IndexedConsumer}}(),
+            Vector{Union{ScalarAux,IndexedAux}}(),
             Implicitvar[],
             Dict{Symbol, ImplicitvarRef}(),
 
@@ -404,7 +178,10 @@ end
 
 
 
+function get_name(mpsge_var::MPSGERef, include_subindex=false)
+    return :X
 
+end
 
 function get_name(sector::SectorRef, include_subindex=false)
     if sector.subindex===nothing || include_subindex==false
@@ -605,6 +382,10 @@ julia> add!(m, Production())
 function add!(m::Model, s::ScalarSector)
     m._jump_model = nothing
     push!(m._sectors, s)
+
+    s_ref = SectorRef(m, length(m._sectors), nothing, nothing)
+    m._object_dict[s_ref] = s
+
     return SectorRef(m, length(m._sectors), nothing, nothing)
 end
 
@@ -617,6 +398,7 @@ function add!(m::Model, s::IndexedSector)
     for i in CartesianIndices(temp_array)
         temp_array[i] = SectorRef(m, length(m._sectors), i, Tuple(s.indices[j][v] for (j,v) in enumerate(Tuple(i))))
     end
+
     return JuMP.Containers.DenseAxisArray(temp_array, s.indices...)
 end
 

--- a/src/model.jl
+++ b/src/model.jl
@@ -198,6 +198,13 @@ function get_name(im::ImplicitvarRef, include_subindex=false)
     # end 
 end
 
+function get_name(P::ParameterRef, include_subindex=false)
+    if P.subindex===nothing || include_subindex==false
+        return P.name
+    else
+        return Symbol("$(P.name)[$(join(string.(P.subindex_names), ", "))]") 
+    end
+end
 
 get_full(s::MPSGERef) = s.model[s.name]
 get_full(p::ParameterRef) = p.model[p.name]
@@ -594,7 +601,7 @@ end
 ######################
 
 function get_nested_commodity(x::SectorRef, name::Symbol)
-    for (i,v) in enumerate(commodities(model))
+    for (i,v) in enumerate(commodities(x.model))
         if v.name == Symbol("P$(get_name(x))→$name")
             return CommodityRef(x.model, i, v.name, nothing, nothing)
         end

--- a/src/model.jl
+++ b/src/model.jl
@@ -128,7 +128,7 @@ julia> foo = Model()
 ```
 """
 mutable struct Model
-    _object_dict::Dict
+    _object_dict::Dict{Symbol,Any}
 
     _parameters::Vector{Parameter}
     _sectors::Vector{Union{ScalarSector,IndexedSector}}
@@ -149,7 +149,7 @@ mutable struct Model
 
     function Model()
         return new(
-            Dict(),
+            Dict{Symbol,Any}(),
             Parameter[],
             Vector{Union{ScalarSector,IndexedSector}}(),
             Vector{Union{ScalarCommodity,IndexedCommodity}}(),

--- a/src/model.jl
+++ b/src/model.jl
@@ -182,42 +182,13 @@ function Base.getindex(m::Model,idx::Symbol)
 end
 
 function get_name(mpsge_var::MPSGERef, include_subindex=false)
-    #if mpsge_var.subindex===nothing || !include_subindex
-        #return mpsge_var.model.
-
-end
-
-function get_name(sector::SectorRef, include_subindex=false)
-    if sector.subindex===nothing || include_subindex==false
-        return sector.model._sectors[sector.index].name
+    if mpsge_var.subindex===nothing || include_subindex==false
+        return mpsge_var.name
     else
-        return Symbol("$(sector.model._sectors[sector.index].name )[$(join(string.(sector.subindex_names), ", "))]") 
+        return Symbol("$(mpsge_var.name)[$(join(string.(mpsge_var.subindex_names), ", "))]") 
     end
 end
 
-function get_name(commodity::CommodityRef, include_subindex=false)
-    if commodity.subindex===nothing || include_subindex==false
-        return commodity.model._commodities[commodity.index].name
-    else
-        return Symbol("$(commodity.model._commodities[commodity.index].name )[$(join(string.(commodity.subindex_names), ", "))]") 
-    end
-end
-
-function get_name(consumer::ConsumerRef, include_subindex=false)
-    if consumer.subindex===nothing || include_subindex===false
-        return consumer.model._consumers[consumer.index].name
-    else
-        return Symbol("$(consumer.model._consumers[consumer.index].name )[$(join(string.(consumer.subindex_names), ", "))]") 
-    end 
-end
-
-function get_name(aux::AuxRef, include_subindex=false)
-    if aux.subindex===nothing || include_subindex===false
-        return aux.model._auxs[aux.index].name
-    else
-        return Symbol("$(aux.model._auxs[aux.index].name )[$(join(string.(aux.subindex_names), ", "))]") 
-    end 
-end
 
 function get_name(im::ImplicitvarRef, include_subindex=false)
     # if im.subindex===nothing || include_subindex===false
@@ -509,7 +480,7 @@ end
 function add!(m::Model, im::Implicitvar)
     m._jump_model = nothing
     push!(m._implicitvars, im)
-    push!(m._implicitvarsDict,im.name=>ImplicitvarRef(m, length(m._implicitvars), nothing, nothing))
+    push!(m._implicitvarsDict,im.name=>ImplicitvarRef(m, length(m._implicitvars),im.name, nothing, nothing))
 end
 
 
@@ -685,7 +656,7 @@ end
 function get_nested_commodity(x::SectorRef, name::Symbol)
     for (i,v) in enumerate(x.model._commodities)
         if v.name == Symbol("P$(get_name(x))→$name")
-            return CommodityRef(x.model, i, nothing, nothing)
+            return CommodityRef(x.model, i, v.name, nothing, nothing)
         end
     end
 end

--- a/src/model.jl
+++ b/src/model.jl
@@ -528,15 +528,28 @@ end
 julia> set_value(var, 1.3)
 ```
 """
-function JuMP.set_value(parameter::ParameterRef, new_value::Float64)
-    #p = parameter.model._parameters[parameter.index]
-    p = get_full(parameter)
-    if p isa ScalarParameter
-        p.value = new_value
-    else
-        p.value[parameter.subindex] = new_value
-    end
+function JuMP.set_value(V::MPSGERef, new_value::Float64)
+    var = get_full(V)
+    _set_value(var, V, new_value)
     return nothing
+end
+
+function _set_value(var::MPSGEScalar, V::MPSGERef, new_value::Float64)
+    var.benchmark = new_value
+end
+
+function _set_value(var::MPSGEIndexed, V::MPSGERef, new_value::Float64)
+    var.benchmark[V.subindex] = new_value
+end
+
+
+
+function _set_value(var::ScalarParameter, V::MPSGERef, new_value::Float64)
+    var.value = new_value
+end
+
+function _set_value(var::IndexedParameter, V::MPSGERef, new_value::Float64)
+    var.value[V.subindex] = new_value
 end
 
 function get_value(parameter::ParameterRef)
@@ -546,52 +559,6 @@ function get_value(parameter::ParameterRef)
     else
         return p.value[parameter.subindex]
     end
-end
-
-function JuMP.set_value(consumer::ConsumerRef, new_value::Float64)
-    #c = consumer.model._consumers[consumer.index]
-    c = get_full(consumer)
-    if c isa ScalarConsumer
-        c.benchmark = new_value
-    else
-        c.benchmark[consumer.subindex] = new_value
-    end
-    return nothing
-end
-
-function JuMP.set_value(sector::SectorRef, new_value::Float64)
-    #s = sector.model._sectors[sector.index]
-    s = get_full(sector)
-    if s isa ScalarSector
-        s.benchmark = new_value
-    else
-        s.benchmark[sector.subindex] = new_value
-    end
-    return nothing
-end
-
-function JuMP.set_value(aux::AuxRef, new_value::Float64)
-    #a = aux.model._auxs[aux.index]
-    a = get_full(aux)
-    if a isa ScalarAux
-        a.benchmark = new_value
-    else
-        a.benchmark[aux.subindex] = new_value
-    end
-    return nothing
-end
-
-function JuMP.set_value(commodity::CommodityRef, new_value::Float64)
-    #c = commodity.model._commodities[commodity.index]
-    c = get_full(commodity)
-    if c isa ScalarCommodity
-        c.benchmark = new_value
-    else
-        c.benchmark[commodity.subindex] = new_value
-    end
-    return nothing
-
-    # c.model._commodities[c.index].benchmark = new_value
 end
 
 

--- a/src/model.jl
+++ b/src/model.jl
@@ -336,6 +336,7 @@ end
 function _add!(m::Model,s::MPSGEIndexed,output_type, model_array)
     m._jump_model = nothing
     push!(model_array, s)
+    @assert s.name ∉ keys(m._object_dict) "Variable $(s.name) already associated with model"
     m._object_dict[s.name] = s
 
     temp_array = Array{output_type}(undef, length.(s.indices)...)
@@ -405,6 +406,7 @@ end
 function add!(m::Model, p::ScalarParameter)
     m._jump_model = nothing
     push!(m._parameters, p)
+    @assert p.name ∉ keys(m._object_dict) "Variable $(s.name) already associated with model"
     m._object_dict[p.name] = p
 
     return ParameterRef(m, length(m._parameters),p.name, nothing, nothing)
@@ -413,6 +415,7 @@ end
 function add!(m::Model, p::IndexedParameter)
     m._jump_model = nothing
     push!(m._parameters, p)
+    @assert p.name ∉ keys(m._object_dict) "Variable $(s.name) already associated with model"
     m._object_dict[p.name] = p
 
     temp_array = Array{ParameterRef}(undef, length.(p.indices)...)

--- a/src/model.jl
+++ b/src/model.jl
@@ -594,7 +594,7 @@ end
 ######################
 
 function get_nested_commodity(x::SectorRef, name::Symbol)
-    for (i,v) in enumerate(x.model._commodities)
+    for (i,v) in enumerate(commodities(model))
         if v.name == Symbol("P$(get_name(x))→$name")
             return CommodityRef(x.model, i, v.name, nothing, nothing)
         end
@@ -640,7 +640,7 @@ end
 #############################
 ## Extracting Model Fields ##
 #############################
-parameters(m::model) = m._parameters
+parameters(m::Model) = m._parameters
 sectors(m::Model) = m._sectors
 commodities(m::Model) = m._commodities
 consumers(m::Model) = m._consumers

--- a/src/model.jl
+++ b/src/model.jl
@@ -220,7 +220,7 @@ end
 
 function get_consumer_total_endowment(jm, m, c::ScalarConsumer)
     endowments = []
-    for d in m._demands
+    for d in demands(m)
         if get_full(d.consumer) == c
             push!(endowments, 
                 +(
@@ -237,7 +237,7 @@ end
 
 function get_consumer_total_endowment(jm, m, c::IndexedConsumer, i)
     endowments = []
-    for d in m._demands
+    for d in demands(m)
         c_for_d = get_full(d.consumer)
         
         if c_for_d == c && d.consumer.subindex_names == i
@@ -254,7 +254,7 @@ end
 
 function get_consumer_total_endowment_old(jm, m, c::ScalarConsumer)
     endowments = []
-    for d in m._demands
+    for d in demands(m)
         if get_full(d.consumer) == c
             push!(endowments, :(
                 +($((:($(en.quantity) * 
@@ -270,7 +270,7 @@ end
 
 function get_consumer_total_endowment_old(jm, m, c::IndexedConsumer, i)
     endowments = []
-    for d in m._demands
+    for d in demands(m)
         c_for_d = get_full(d.consumer)
         
         if c_for_d == c && d.consumer.subindex_names == i

--- a/src/model.jl
+++ b/src/model.jl
@@ -177,6 +177,9 @@ mutable struct Model
 end
 
 
+function Base.getindex(m::Model,idx::Symbol)
+    return m._object_dict[idx]
+end
 
 function get_name(mpsge_var::MPSGERef, include_subindex=false)
     #if mpsge_var.subindex===nothing || !include_subindex

--- a/src/show.jl
+++ b/src/show.jl
@@ -1,27 +1,27 @@
 function Base.show(io::IO, m::Model)
-    println(io, "MPSGE model with $(length(m._sectors)) sectors, $(length(m._commodities)) commodities and $(length(m._consumers)) consumers.")
+    println(io, "MPSGE model with $(length(sectors(m))) sectors, $(length(commodities(m))) commodities and $(length(consumers(m))) consumers.")
 
-    if length(m._sectors) > 0
+    if length(sectors(m)) > 0
         print(io, "  Sectors: ")
-        print(io, join(["$(s.name)" for s in m._sectors], ", "))
+        print(io, join(["$(s.name)" for s in sectors(m)], ", "))
         println(io)
     end
 
-    if length(m._commodities) > 0
+    if length(commodities(m)) > 0
         print(io, "  Commodities: ")
-        print(io, join(["$(c.name)" for c in m._commodities], ", "))
+        print(io, join(["$(c.name)" for c in commodities(m)], ", "))
         println(io)
     end
 
-    if length(m._consumers) > 0
+    if length(consumers(m)) > 0
         print(io, "  Consumers: ")
-        print(io, join(["$(c.name)" for c in m._consumers], ", "))
+        print(io, join(["$(c.name)" for c in consumers(m)], ", "))
         println(io)
     end
 
-    if length(m._auxs) > 0
+    if length(auxs(m)) > 0
         print(io, "  Auxs: ")
-        print(io, join(["$(a.name)" for a in m._auxs], ", "))
+        print(io, join(["$(a.name)" for a in auxs(m)], ", "))
         println(io)
     end
 

--- a/src/structs/references.jl
+++ b/src/structs/references.jl
@@ -3,6 +3,7 @@ abstract type MPSGERef end
 struct ParameterRef <: MPSGERef
     model
     index::Int
+    name::Symbol
     subindex::Any
     subindex_names::Any
 end
@@ -10,6 +11,7 @@ end
 struct SectorRef <: MPSGERef
     model
     index::Int
+    name::Symbol
     subindex::Any
     subindex_names::Any
 end
@@ -17,6 +19,7 @@ end
 struct CommodityRef <: MPSGERef
     model
     index::Int
+    name::Symbol
     subindex::Any
     subindex_names::Any
 end
@@ -24,6 +27,7 @@ end
 struct ConsumerRef <: MPSGERef
     model
     index::Int
+    name::Symbol
     subindex::Any
     subindex_names::Any
 end
@@ -31,6 +35,7 @@ end
 struct AuxRef <: MPSGERef
     model
     index::Int
+    name::Symbol
     subindex::Any
     subindex_names::Any
 end
@@ -38,6 +43,7 @@ end
 struct ImplicitvarRef <: MPSGERef
     model
     index::Int
+    name::Symbol
     subindex::Any
     subindex_names::Any
 end

--- a/src/structs/references.jl
+++ b/src/structs/references.jl
@@ -1,0 +1,43 @@
+abstract type MPSGERef end
+
+struct ParameterRef <: MPSGERef
+    model
+    index::Int
+    subindex::Any
+    subindex_names::Any
+end
+
+struct SectorRef <: MPSGERef
+    model
+    index::Int
+    subindex::Any
+    subindex_names::Any
+end
+
+struct CommodityRef <: MPSGERef
+    model
+    index::Int
+    subindex::Any
+    subindex_names::Any
+end
+
+struct ConsumerRef <: MPSGERef
+    model
+    index::Int
+    subindex::Any
+    subindex_names::Any
+end
+
+struct AuxRef <: MPSGERef
+    model
+    index::Int
+    subindex::Any
+    subindex_names::Any
+end
+
+struct ImplicitvarRef <: MPSGERef
+    model
+    index::Int
+    subindex::Any
+    subindex_names::Any
+end

--- a/src/structs/variables.jl
+++ b/src/structs/variables.jl
@@ -1,0 +1,193 @@
+abstract type MPSGEVariable end
+
+abstract type MPSGEScalar <: MPSGEVariable end
+abstract type MPSGEIndexed <: MPSGEVariable end
+
+"""
+    Parameter(:symbol; indices, value::Float64=1., string)
+    Struct that holds the name, indices if IndexedParameter, value, and optional description of a parameter within the model.
+### Options
+    Parameter::ScalarParameter, IndexedParameter
+### Example
+```julia-repl
+julia> P = add!(Parameter(model, :P, value=1., description="Elasticity"))
+julia> sectors = [:s1, :s2]
+julia> P = add!(Parameter(model, :P, indices=(,sectors), value=1., description="Elasticity parameters for X Sector "))
+```
+"""
+abstract type Parameter end;
+
+mutable struct ScalarParameter <: Parameter
+    name::Symbol
+    value::Float64
+    description::String
+
+    function ScalarParameter(name::Symbol; value::Float64=1., description::AbstractString="")
+        return new(name, value, description)
+    end
+end
+
+mutable struct IndexedParameter <: Parameter
+    name::Symbol
+    indices::Any
+    value::DenseAxisArray
+    description::String
+
+    function IndexedParameter(name::Symbol, indices; value::Union{Array{Float64},Array{Int}}, description::AbstractString="")
+            return new(name, indices, DenseAxisArray(Float64.(value), indices...), description)
+
+    end
+end
+
+function Parameter(name; indices=nothing, kwargs...)
+    return indices===nothing ? ScalarParameter(name; kwargs...) : IndexedParameter(name, indices; kwargs...)
+end
+
+#abstract type Sector end;
+
+mutable struct ScalarSector <: MPSGEScalar
+    name::Symbol
+    benchmark::Float64
+    lower_bound::Float64
+    upper_bound::Float64
+    description::String
+    fixed::Bool
+
+    function ScalarSector(name::Symbol; description::AbstractString="", lower_bound::Float64=0.0, upper_bound=10e100, benchmark::Float64=1., fixed=false)
+        return new(name, benchmark, lower_bound, upper_bound, description, fixed)
+    end
+end
+
+mutable struct IndexedSector <: MPSGEIndexed
+    name::Symbol
+    indices::Any
+    benchmark::DenseAxisArray
+    lower_bound::DenseAxisArray
+    upper_bound::DenseAxisArray
+    description::String
+    fixed::DenseAxisArray
+
+    function IndexedSector(name::Symbol, indices; benchmark::Float64=1., lower_bound::Float64=0.0, upper_bound::Float64=10e100, description::AbstractString="",  fixed=false)
+        return new(name, indices, DenseAxisArray(fill(benchmark, length.(indices)...), indices...), DenseAxisArray(fill(lower_bound, length.(indices)...), indices...), DenseAxisArray(fill(upper_bound, length.(indices)...), indices...), description, DenseAxisArray(fill(fixed, length.(indices)...), indices...))
+    end
+end
+
+"""
+    Sector(:symbol; indices, value::Float64=1., string)
+    Struct that holds the name, (indices if IndexedSector), value, and optional description of a sector within the model.
+### Options
+    Sector::ScalarSector, IndexedSector
+### Example
+```julia-repl
+julia> S = add!(Sector(model, :S, value=1., description="Sector S"))
+julia> sectors = [:s1, :s2]
+julia> P = add!(Sector(model, :S, indices=(,sectors), value=1., description="S[:s1] and S[:s2] Sectors"))
+```
+"""
+function Sector(name; indices=nothing, kwargs...)
+    return indices===nothing ? ScalarSector(name; kwargs...) : IndexedSector(name, indices; kwargs...)
+end
+
+abstract type Commodity end;
+
+mutable struct ScalarCommodity <: MPSGEScalar
+    name::Symbol
+    benchmark::Float64
+    lower_bound::Float64
+    upper_bound::Float64
+    description::String
+    fixed::Bool
+
+    function ScalarCommodity(name::Symbol; description::AbstractString="", lower_bound::Float64=0.001, upper_bound::Float64=10e100, benchmark::Float64=1., fixed=false)
+        return new(name, benchmark, lower_bound, upper_bound, description, fixed)
+    end
+end
+
+mutable struct IndexedCommodity <: MPSGEIndexed
+    name::Symbol
+    indices::Any
+    benchmark::DenseAxisArray
+    lower_bound::DenseAxisArray
+    upper_bound::DenseAxisArray
+    description::String
+    fixed::DenseAxisArray
+
+    function IndexedCommodity(name::Symbol, indices; benchmark::Float64=1., lower_bound::Float64=0.001, upper_bound::Float64=10e100, description::AbstractString="", fixed=false)
+        return new(name, indices, DenseAxisArray(fill(benchmark, length.(indices)...), indices...), DenseAxisArray(fill(lower_bound, length.(indices)...), indices...), DenseAxisArray(fill(upper_bound, length.(indices)...), indices...), description, DenseAxisArray(fill(fixed, length.(indices)...), indices...))
+    end
+end
+
+function Commodity(name; indices=nothing, kwargs...)
+    return indices===nothing ? ScalarCommodity(name; kwargs...) : IndexedCommodity(name, indices; kwargs...)
+end
+
+abstract type Consumer end;
+
+mutable struct ScalarConsumer <: MPSGEScalar
+    name::Symbol
+    benchmark::Float64
+    lower_bound::Float64
+    upper_bound::Float64
+    description::String
+    fixed::Bool
+    
+    function ScalarConsumer(name::Symbol; description::AbstractString="", lower_bound::Float64=0.0, upper_bound::Float64=10e100, benchmark::Float64=1., fixed=false)
+        return new(name, benchmark, lower_bound, upper_bound, description, fixed)
+    end
+end
+
+mutable struct IndexedConsumer <: MPSGEIndexed
+    name::Symbol
+    indices::Any
+    benchmark::DenseAxisArray
+    lower_bound::DenseAxisArray
+    upper_bound::DenseAxisArray
+    description::String
+    fixed::DenseAxisArray
+
+    function IndexedConsumer(name::Symbol, indices; benchmark::Float64=1., lower_bound::Float64=0.0, upper_bound::Float64=10e100, description::AbstractString="", fixed=false)
+        return new(name, indices, DenseAxisArray(fill(benchmark, length.(indices)...), indices...), DenseAxisArray(fill(lower_bound, length.(indices)...), indices...), DenseAxisArray(fill(upper_bound, length.(indices)...), indices...), description, DenseAxisArray(fill(fixed, length.(indices)...), indices...))
+    end
+end
+
+function Consumer(name; indices=nothing, kwargs...)
+    return indices===nothing ? ScalarConsumer(name; kwargs...) : IndexedConsumer(name, indices; kwargs...)
+end
+
+abstract type Aux end;
+
+mutable struct ScalarAux <: MPSGEScalar
+    name::Symbol
+    benchmark::Float64
+    lower_bound::Float64
+    upper_bound::Float64
+    description::String
+    fixed::Bool
+
+    function ScalarAux(name::Symbol; description::AbstractString="", lower_bound::Float64=0.0, upper_bound::Float64=10e100, benchmark::Float64=1., fixed=false)
+        return new(name, benchmark, lower_bound, upper_bound, description, fixed)
+    end
+end
+
+mutable struct IndexedAux <: MPSGEIndexed
+    name::Symbol
+    indices::Any
+    benchmark::DenseAxisArray
+    lower_bound::DenseAxisArray
+    upper_bound::DenseAxisArray
+    description::String
+    fixed::DenseAxisArray
+
+    function IndexedAux(name::Symbol, indices; benchmark::Float64=1., lower_bound::Float64=0.0, upper_bound::Float64=10e100, description::AbstractString="", fixed=false)
+        return new(name, indices, DenseAxisArray(fill(benchmark, length.(indices)...), indices...), DenseAxisArray(fill(lower_bound, length.(indices)...), indices...), DenseAxisArray(fill(upper_bound, length.(indices)...), indices...), description, DenseAxisArray(fill(fixed, length.(indices)...), indices...))
+    end
+end
+
+function Aux(name; indices=nothing, kwargs...)
+    return indices===nothing ? ScalarAux(name; kwargs...) : IndexedAux(name, indices; kwargs...)
+end
+
+struct Tax
+    rate::Union{Float64,Expr}
+    agent::ConsumerRef
+end


### PR DESCRIPTION
# Motivation

There is currently a lot of moderately duplicate code that can be simplified. Functions like `get_name`, `get_full` and `add!` are the primary targets.

# Solution

Create four new abstract types `MPSGERef`, `MPSGEVariable`, `MPSGEScalar`, and `MPSGEIndexed`. Update each concrete type accordingly. This does require the removal of the abstract types similar to `Sector`, but these are only used in the struct `Model` and have been temporarily replaced with a type Union. 

These changes lead to the natural consequence of abstracting much of the duplicate code. 

`add!` has several dispatches to accommodate returning different concrete types and the list to be appended to.

I've also extended the Ref structs with a `name` field. This allows the addition of an `_object_dict{Symbol,Any}` field into `Model` and a getindex that will extract variables by name. These changes simplify both `get_name` and `get_full` significantly. 

# Grand Plans

I want to remove the Model fields relating to variables. It *should* be efficient to filter the `_object_dict` for Sectors, Commodities, etc. 

The grand plans are not implemented as they may be substantial and I'd like feedback and thoughts.

# Closing Thoughts

I'm marking this as a draft for the moment. I've ensured it passes all tests.