### PR TITLE
Add initial values to sums in default numeraire calculation

### DIFF
--- a/src/build.jl
+++ b/src/build.jl
@@ -222,7 +222,7 @@ function consumer_income(consumer)
         )
     else
         __value_function(x) = is_fixed(x) ? fix_value(x) : value(x)
-        new_start = sum(raw_quantity(__value_function, e) for (_,e)∈endowments(demand(consumer)))
+        new_start = sum(raw_quantity(__value_function, e) for (_,e)∈endowments(demand(consumer)); init=0)
         new_start += -value(
             __value_function,
             sum(tau(sector, consumer) for sector in production_sectors(m))

--- a/src/build.jl
+++ b/src/build.jl
@@ -214,18 +214,18 @@ function consumer_income(consumer)
                 start_value, 
                 endowment
             ) 
-            for (_,endowment)∈endowments(demand(consumer))
+            for (_,endowment)∈endowments(demand(consumer)); init=0
         )
         new_start += -value(
             start_value, 
-            sum(tau(sector, consumer) for sector in production_sectors(m))
+            sum(tau(sector, consumer) for sector in production_sectors(m); init = 0)
         )
     else
         __value_function(x) = is_fixed(x) ? fix_value(x) : value(x)
         new_start = sum(raw_quantity(__value_function, e) for (_,e)∈endowments(demand(consumer)); init=0)
         new_start += -value(
             __value_function,
-            sum(tau(sector, consumer) for sector in production_sectors(m))
+            sum(tau(sector, consumer) for sector in production_sectors(m); init=0)
         )
     end
     return new_start


### PR DESCRIPTION
The function `consumer_income` is used when calculating the default numeraire. This lacked initial values in the summations which caused errors when there were no endowments.