### PR TITLE
Reduce model size and solve complexity

### DIFF
--- a/src/build.jl
+++ b/src/build.jl
@@ -160,19 +160,12 @@ end
 ## Constraints ##
 #################
 
-function cost_function(P::Production)
-    quantity(P.input)*P.input.cost_function
-end
-
-function revenue_function(P::Production)
-    quantity(P.output)*P.output.cost_function
-end
 
 function zero_profit(S::MPSGE.ScalarSector)
     M = model(S)
     jm = jump_model(M)
     P = production(S)
-    @expression(jm, cost_function(P) - revenue_function(P))
+    @expression(jm, cost_function(P; virtual=true) - revenue_function(P; virtual=true))
 end
 
 function market_clearance(C::ScalarCommodity)

--- a/src/build.jl
+++ b/src/build.jl
@@ -37,11 +37,6 @@ end
 ## Compensated Demand ##
 ########################
 
-function compensated_demands(S::ScalarSector)
-    P = production(S)
-    return P.compensated_demands
-end
-
 function netput_dict(S::ScalarSector)
     P = production(S)
     return P.netputs
@@ -65,26 +60,26 @@ function parent_name_chain(N::MPSGE.Netput)
     return parent_names
 end
 
-function compensated_demand(S::ScalarSector, C::ScalarCommodity, nest::Symbol)
-    cd = MPSGE.compensated_demands(S)
-    all_netputs = MPSGE.netput_dict(S)
-    if !haskey(all_netputs, C)
-        return 0
+function compensated_demand(N::MPSGE.Netput; virtual = false)
+    child, parent = N, MPSGE.parent(N)[1]
+    sign = -MPSGE.netput_sign(N)
+    compensated_demand = sign * MPSGE.base_quantity(N)
+    while !isnothing(parent)
+        if MPSGE.elasticity(parent)!=0
+            compensated_demand *= (cost_function(parent; virtual=virtual)/cost_function(child; virtual=virtual)) ^ (sign*MPSGE.elasticity(parent))
+        end
+        child,parent = parent, MPSGE.parent(parent)
     end
-    netputs = [n for n∈all_netputs[C] if nest∈parent_name_chain(n)]
-
-    return sum(sum(cd[netput]) for netput∈netputs)
-
+    return compensated_demand
 end
 
-function compensated_demand(S::ScalarSector,C::ScalarCommodity)
-    cd = compensated_demands(S)
-    netputs = netput_dict(S)
-    if !haskey(netputs, C)
-        return 0
-    end
-    sum(sum(cd[netput]) for netput∈netputs[C])
-    #sum(sum(v) for (netput, v)∈cd if commodity(netput) == C; init = 0)
+function compensated_demand(S::ScalarSector, C::ScalarCommodity; virtual = false)
+    return sum(compensated_demand.(netputs(S,C); virtual=virtual); init = 0)
+end
+
+function compensated_demand(S::ScalarSector, C::ScalarCommodity, nest::Symbol; virtual = false)
+    N = [n for n∈netputs(S,C) if nest∈parent_name_chain(n)]
+    return sum(compensated_demand.(N, virtual = virtual); init = 0)
 end
 
 
@@ -103,7 +98,7 @@ end
 function tau(S::ScalarSector,H::ScalarConsumer)
     P = production(S)
     #jm = jump_model(model(S))
-    -sum( sum(compensated_demands) * total_tax(netput, H) * commodity(netput) for (netput, compensated_demands)∈P.compensated_demands if total_tax(netput,H)!=0; init=0)
+    -sum( compensated_demand(netput) * total_tax(netput, H) * commodity(netput) for (_,N)∈netputs(P) for netput∈N if total_tax(netput,H)!=0; init=0)
 end
 
 
@@ -161,20 +156,20 @@ end
 #################
 
 
-function zero_profit(S::MPSGE.ScalarSector)
+function zero_profit(S::MPSGE.ScalarSector; virtual = false)
     M = model(S)
     jm = jump_model(M)
     P = production(S)
-    @expression(jm, cost_function(P; virtual=true) - revenue_function(P; virtual=true))
+    @expression(jm, cost_function(P; virtual=virtual) - revenue_function(P; virtual=virtual))
 end
 
-function market_clearance(C::ScalarCommodity)
+function market_clearance(C::ScalarCommodity; virtual = false)
     M = model(C)
     jm = jump_model(M)
-    @expression(jm, -sum(compensated_demand(S,C) * get_variable(S) for S∈sectors(C);init=0) + sum( endowment(H,C) - demand(H,C) for H∈consumers(M); init=0))
+    @expression(jm, -sum(compensated_demand(S,C;virtual = virtual) * get_variable(S) for S∈sectors(C);init=0) + sum( endowment(H,C) - demand(H,C) for H∈consumers(M); init=0))
 end
 
-function income_balance(H::ScalarConsumer)
+function income_balance(H::ScalarConsumer; virtual = false)
     M = model(H)
     jm = jump_model(M)
     @expression(jm, get_variable(H) - (sum(get_variable(endowment(H,C))* get_variable(C) for C∈commodities(M) if endowment(H,C)!=0) - sum(tau(S,H)*S for S∈production_sectors(M) if tau(S,H)!=0; init=0)))
@@ -186,15 +181,15 @@ function build_constraints!(M::MPSGEModel)
     jm = jump_model(M)
 
     JuMP.@constraint(jm, zero_profit[S = MPSGE.production_sectors(M)],
-        MPSGE.zero_profit(S) ⟂ get_variable(S)
+        MPSGE.zero_profit(S; virtual = true) ⟂ get_variable(S)
     )
     
     JuMP.@constraint(jm, market_clearance[C = MPSGE.commodities(M)],
-        MPSGE.market_clearance(C) ⟂ get_variable(C)
+        MPSGE.market_clearance(C; virtual = true) ⟂ get_variable(C)
     )
     
     JuMP.@constraint(jm, income_balance[H = MPSGE.consumers(M)],
-        MPSGE.income_balance(H) ⟂ get_variable(H)
+        MPSGE.income_balance(H; virtual = true) ⟂ get_variable(H)
     )
 
     aux_cons = aux_constraints(M)

--- a/src/build.jl
+++ b/src/build.jl
@@ -160,10 +160,19 @@ end
 ## Constraints ##
 #################
 
-function zero_profit(S::ScalarSector)
+function cost_function(P::Production)
+    quantity(P.input)*P.input.cost_function
+end
+
+function revenue_function(P::Production)
+    quantity(P.output)*P.output.cost_function
+end
+
+function zero_profit(S::MPSGE.ScalarSector)
     M = model(S)
     jm = jump_model(M)
-    @expression(jm, sum(compensated_demand(S,C)*get_variable(C) for C∈commodities(S)) - sum(tau(S,H) for H∈consumers(M) if tau(S,H)!=0; init=0))
+    P = production(S)
+    @expression(jm, cost_function(P) - revenue_function(P))
 end
 
 function market_clearance(C::ScalarCommodity)

--- a/src/convenience_functions.jl
+++ b/src/convenience_functions.jl
@@ -31,3 +31,16 @@ JuMP.set_lower_bound(X::MPSGEScalarVariable, val::Real) = JuMP.set_lower_bound(g
 JuMP.set_upper_bound(X::MPSGEScalarVariable, val::Real) = JuMP.set_upper_bound(get_variable(X), val)
 JuMP.lower_bound(X::MPSGEScalarVariable) = JuMP.lower_bound(get_variable(X))
 JuMP.upper_bound(X::MPSGEScalarVariable) = JuMP.upper_bound(get_variable(X))
+
+
+function JuMP.all_variables(M::MPSGEModel)
+
+    X = [s for (_,s) in M.object_dict] |>
+        x -> MPSGE.extract_scalars.(x) |>  
+        x -> Iterators.flatten(x) |>
+        x -> collect(x)
+
+    return X
+
+end
+

--- a/src/production.jl
+++ b/src/production.jl
@@ -198,13 +198,11 @@ function build_cost_function!(N::Node, S::ScalarSector)
         cost_function = CES(N)
     end
 
-    if length(N.children) < 1000
-        N.cost_function = cost_function
-    else
-        jm = jump_model(model(S))
-        N.cost_function = @variable(jm, start = 1) 
-        @constraint(jm, cost_function - N.cost_function ⟂ N.cost_function)
-    end
+    jm = jump_model(model(S))
+    N.cost_function_virtual = @variable(jm, start = 1) 
+    N.cost_function = cost_function
+    @constraint(jm, cost_function - N.cost_function_virtual ⟂ N.cost_function_virtual)
+    #end
 
 end
 

--- a/src/production.jl
+++ b/src/production.jl
@@ -120,18 +120,15 @@ function Production(
     @assert !(!isnothing(input) && isnothing(output))  "Production block for $(sector) has a 0 quantity in output but not input."
     @assert !(isnothing(input)  && !isnothing(output)) "Production block for $(sector) has a 0 quantity in input but not output."
 
+    if isnothing(input) && isnothing(output)
+        return Production(sector, netput_dict, nothing, nothing)
+    end
+
+
     # Initialize cost functions - Should check if things are nothing
     for nest∈reverse(collect(keys(node_dict)))
         for node∈node_dict[nest]
             build_cost_function!(node, sector)
-        end
-    end
-
-    # Build compensated demands
-    compensated_demands = Dict{Netput, Vector{MPSGEquantity}}()
-    for (_, netput_vector)∈netput_dict
-        for netput∈netput_vector
-            compensated_demands[netput] = build_compensated_demand.(Ref(netput),netput.parents)
         end
     end
 
@@ -141,7 +138,7 @@ function Production(
         push!(M.commodities[C], sector)
     end
 
-    return Production(sector, netput_dict, compensated_demands, input, output)
+    return Production(sector, netput_dict, input, output)
 end
 
 #####################
@@ -168,7 +165,7 @@ end
 ## Cost Functions ##
 ####################
 
-function cost_function(N::Netput)
+function cost_function(N::Netput; virtual = false)
     C = commodity(N)
     sign = N.netput_sign
     rp = reference_price(N)
@@ -199,7 +196,7 @@ function build_cost_function!(N::Node, S::ScalarSector)
     end
 
     jm = jump_model(model(S))
-    N.cost_function_virtual = @variable(jm, start = 1) 
+    N.cost_function_virtual = @variable(jm, start = value(start_value, cost_function)) 
     N.cost_function = cost_function
     @constraint(jm, cost_function - N.cost_function_virtual ⟂ N.cost_function_virtual)
     #end
@@ -214,17 +211,4 @@ end
 function CES(N::Node)#P::ScalarProduction, T::ScalarNest, sign::Int)
     sign = N.netput_sign
     return sum(quantity(child)/quantity(N) * cost_function(child)^(1+sign*elasticity(N)) for child in children(N); init=0) ^ (1/(1+sign*elasticity(N)))
-end
-
-function build_compensated_demand(base_netput::Netput, parent_node::Node)
-    child, parent = base_netput, parent_node
-    sign = child.netput_sign
-    compensated_demand = -sign * base_quantity(child)
-    while !isnothing(parent)
-        if elasticity(parent)!=0
-            compensated_demand *= (cost_function(parent)/cost_function(child)) ^ (-sign*elasticity(parent))
-        end
-        child,parent = parent, parent.parent
-    end
-    return compensated_demand
 end

--- a/src/report.jl
+++ b/src/report.jl
@@ -7,12 +7,19 @@ function generate_report(M::MPSGEModel)
     m = jump_model(M)
     
     out = []
-
-    #mapping = Dict()
+    mpsge_vars = MPSGE.get_variable.(all_variables(M))
+    
     for ci in all_constraints(m; include_variable_in_set_constraints = false)
         c = constraint_object(ci)
-
         var = extract_variable_ref(c.func[2])
+
+        if var ∉ mpsge_vars
+            continue
+        end
+
+        
+
+        
         val = value(var)
         margin = value(c.func[1])
 

--- a/src/structs.jl
+++ b/src/structs.jl
@@ -371,7 +371,7 @@ parent(N::Node) = N.parent
 
 
 
-cost_function(N::Node) = N.cost_function
+cost_function(N::Node; virtual = false) = !virtual ? N.cost_function : N.cost_function_virtual
 #name(N::Node) = N.data.name
 #elasticity(N::Node) = N.data.elasticity
 
@@ -403,7 +403,8 @@ taxes(N::Netput) = N.taxes
 name(N::Netput) = name(commodity(N))
 #parent(N::Netput) = N.parent
 children(N::Netput) = []
-parents(N::Netput) = N.parents
+parent(N::Netput) = N.parents
+netput_sign(N::Netput) = N.netput_sign
     
 mutable struct Input <: Netput 
     commodity::ScalarCommodity
@@ -411,7 +412,6 @@ mutable struct Input <: Netput
     reference_price::MPSGEquantity
     taxes::Vector{Tax}
     parents::Vector{Node}
-    #cost_function::MPSGEquantity
     netput_sign::Int
     Input( commodity::ScalarCommodity,
             quantity::MPSGEquantity;
@@ -442,7 +442,6 @@ end
 struct Production
     sector::ScalarSector
     netputs::Dict{Commodity, Vector{Netput}}
-    compensated_demands::Dict{Netput,Vector{MPSGEquantity}}
     input::Union{Node, Nothing}
     output::Union{Node, Nothing}
 end
@@ -451,6 +450,10 @@ sector(P::Production) = P.sector
 input(P::Production) = P.input
 output(P::Production) = P.output
 commodities(P::Production) = collect(keys(P.netputs))
+netputs(P::Production) = P.netputs
+netputs(S::ScalarSector, C::ScalarCommodity) = get(netputs(production(S)), C, [])
+
+
 function cost_function(P::Production; virtual = false)
     I = input(P)
     if virtual 

--- a/src/structs.jl
+++ b/src/structs.jl
@@ -451,6 +451,25 @@ sector(P::Production) = P.sector
 input(P::Production) = P.input
 output(P::Production) = P.output
 commodities(P::Production) = collect(keys(P.netputs))
+function cost_function(P::Production; virtual = false)
+    I = input(P)
+    if virtual 
+        quantity(I)*I.cost_function_virtual
+    else
+        quantity(I)*I.cost_function
+    end
+end
+
+function revenue_function(P::Production; virtual = false)
+    O = output(P)
+    if virtual 
+        quantity(O)*O.cost_function_virtual
+    else
+        quantity(O)*O.cost_function
+    end
+end
+
+
 
 ########################
 ## Demands/Endowments ##

--- a/src/structs.jl
+++ b/src/structs.jl
@@ -348,10 +348,11 @@ mutable struct Node
     parent::Union{Node, Nothing}
     children::Vector{Union{Node,Netput}}
     data::ScalarNest
-    cost_function::MPSGEquantity #There may be a better name
+    cost_function_virtual::Union{Nothing,JuMP.VariableRef}
+    cost_function::MPSGEquantity 
     netput_sign::Int
     function Node(data::ScalarNest; children = [], netput_sign::Int = 1)
-        N = new(nothing, children, data, 0, netput_sign) #Cost function is set after trees are built
+        N = new(nothing, children, data, nothing, 0, netput_sign) #Cost function is set after trees are built
         for child in children 
             set_parent!(child, N)
         end


### PR DESCRIPTION
There are a few important changes that need to be addressed, and they are all moderately related.

1. Cost functions are used in every constraint. Before the explicit expression was substituted in each instance. Now we assign each cost function a variable and use that in our constraints.

2. Added a `cost_function` function with a keyword `virtual = false`. If `virtual = false` the explicit cost functions are substituted, and if `virtual = true` the variable subexpression is.

3. We used to store all the compensated demands in the production block. This can be a large amount of unnecessary  memory. This has been removed. Instead we generate compensated demands as they are needed. 

4. Refactored the `compensated_demand` functions. There shouldn't be any affect on existing code, but there is now a keyword `virtual = false` which acts the same as in `cost_function` above. 

There should be no breaking changes. 