### PR TITLE
Upgrade cost and revenue function getters

### DIFF
--- a/src/MPSGE.jl
+++ b/src/MPSGE.jl
@@ -37,10 +37,10 @@ export  MPSGEModel,
 #Struct access
 export  name, quantity, production, jump_model, sectors, commodities,
         consumers, taxes, sector, commodity, consumer, description,
-        set_value!, value, auxiliaries, parameters#, cost_function
+        set_value!, value, auxiliaries, parameters
 
 #Production
-export cost_function, input, output
+export cost_function, revenue_function, input, output
 
 #Model
 export  add_variable!, add!, add_sector!, add_commodity!, add_consumer!,

--- a/src/build.jl
+++ b/src/build.jl
@@ -165,8 +165,8 @@ end
 function zero_profit(S::MPSGE.ScalarSector; virtual = false)
     M = model(S)
     jm = jump_model(M)
-    P = production(S)
-    @expression(jm, cost_function(P; virtual=virtual) - revenue_function(P; virtual=virtual))
+    #P = production(S)
+    @expression(jm, cost_function(S; virtual=virtual) - revenue_function(S; virtual=virtual))
 end
 
 function market_clearance(C::ScalarCommodity; virtual = false)

--- a/src/structs.jl
+++ b/src/structs.jl
@@ -517,9 +517,9 @@ commodity.
 If `virtual` is true, return the virtual revenue functions.
 
 """
-revenue_function(P::Production; virtual = false) = cost_function(P, name(output(P)), virtual = virtual)
+revenue_function(P::Production; virtual = false) = cost_function(P, name(output(P)), virtual = virtual, search = :output)
 revenue_function(S::ScalarSector, nest::Symbol; virtual = false) = cost_function(production(S), nest, virtual = virtual, search = :output)
-revenue_function(S::ScalarSector; virtual = false) = cost_function(production(S), virtual = virtual)
+revenue_function(S::ScalarSector; virtual = false) = revenue_function(production(S); virtual = virtual)
 
 ########################
 ## Demands/Endowments ##

--- a/src/structs.jl
+++ b/src/structs.jl
@@ -480,7 +480,7 @@ end
 function cost_function(P::Production, nest::Symbol; virtual = false, search = :all)
     N = find_nodes(P; search = search)
     if haskey(N, nest)
-        return quantity.(N[nest]).*cost_function.(N[nest]; virtual = virtual)
+        return sum(quantity.(N[nest]).*cost_function.(N[nest]; virtual = virtual))
     end
     return 0
 end


### PR DESCRIPTION
Simplify process of displaying cost/revenue functions. Also add methods to return each given a sector/nest combo. Further, export `revenue_function`.

```julia
using MPSGE

M = MPSGEModel()

@parameters(M, begin
    Q1, 1
    Q2, 1
    Q3, 1
    Q4, 1
    T1, 1
    t1, 1
end)

@sector(M, S)

@commodities(M, begin
    P1
    P2
    P3
    P4
end)

@consumer(M, RA)

@production(M, S, [t=0, s=1, a=>s=.5], begin
    @output(P1, Q1, t)
    @input(P2, Q2, s)
    @input(P3, Q3, a, taxes = [Tax(RA, T1)], reference_price = 1+t1)
    @input(P4, Q4, a)
    @input(P3, Q2, s)
end)


cost_function(S)
cost_function(S, :a)
cost_function(S, :P3)

revenue_function(S)

```