### PR TITLE
Optimizations for large numbers of consumers

### DIFF
--- a/src/build.jl
+++ b/src/build.jl
@@ -94,15 +94,10 @@ function total_tax(N::Netput, H::ScalarConsumer)
     sum(taxes(N, H); init=0)
 end
 
-#temporary fix
-function tau(S::ScalarSector,H::ScalarConsumer)
-    P = production(S)
-    #jm = jump_model(model(S))
-    -sum( compensated_demand(netput) * total_tax(netput, H) * commodity(netput) for (_,N)∈netputs(P) for netput∈N if total_tax(netput,H)!=0; init=0)
-end
 
 function tax_revenue(S::ScalarSector, H::ScalarConsumer; virtual = false)
-    return -sum(compensated_demand(N,virtual=virtual)*total_tax(N,H)*get_variable(S)*get_variable(commodity(N)) for N∈taxes(S,H); init=0)
+    jm = jump_model(model(S))
+    return @expression(jm, -sum(compensated_demand(N,virtual=virtual)*total_tax(N,H)*get_variable(S)*get_variable(commodity(N)) for N∈taxes(S,H); init=0))
 end
 
 ########################
@@ -117,7 +112,7 @@ end
 function is_demand(H,C)
     D = demand(H)
     Final_Demands = final_demands(D)
-    return haskey(Final_Demands, C) && length(Final_Demands[C])!=0
+    return haskey(Final_Demands, C) && !isempty(Final_Demands[C])
 end
 
 

--- a/src/build.jl
+++ b/src/build.jl
@@ -150,7 +150,7 @@ function demand(H::Consumer, C::Commodity)
     total_income = []
     for d in DF
         if !(isa(elasticity(D), Real))
-            income =  @force_nonlinear(
+            income =  @expression(jm,
                 quantity(d)/total_quantity * H/C * ifelse(1*elasticity(D) == 1, 1, (expenditure(D)*reference_price(d)/C)^(elasticity(D)-1))
             )
         elseif elasticity(D) == 1
@@ -162,7 +162,7 @@ function demand(H::Consumer, C::Commodity)
         push!(total_income, income)
     end
 
-    return @force_nonlinear(sum(total_income))
+    return sum(total_income; init = 0)
 end
 
 
@@ -170,7 +170,7 @@ function expenditure(D::ScalarDemand)
     jm = jump_model(model(consumer(D)))
     total_quantity = quantity(D)
     σ = elasticity(D)
-    return @force_nonlinear(sum( quantity(d)/total_quantity * (get_variable(commodity(d))/reference_price(d))^(1-σ) for (_,DF)∈final_demands(D) for d∈DF)^(1/(1-σ)))
+    return @expression(jm,sum( quantity(d)/total_quantity * (get_variable(commodity(d))/reference_price(d))^(1-σ) for (_,DF)∈final_demands(D) for d∈DF)^(1/(1-σ)))
 end
 
 #################

--- a/src/build.jl
+++ b/src/build.jl
@@ -236,8 +236,7 @@ function consumer_income(consumer)
         x -> is_fixed(x) ? fix_value(x) : value(x)
     )
 
-    return value(value_function, sum(get_variable(endowment(consumer,C))* get_variable(C) for C∈household_commodities) - sum(tax_revenue(S,consumer;virtual = true) for S∈production_sectors(M); init=0))
-
+    return sum(value(value_function,get_variable(endowment(consumer,C))* get_variable(C)) for C∈household_commodities) - sum(value(value_function,tax_revenue(S,consumer;virtual = true)) for S∈production_sectors(M); init=0)
 end
 
 
@@ -252,12 +251,9 @@ julia> solve!(m, cumulative_iteration_limit=0)
 function solve!(m::AbstractMPSGEModel; kwargs...)
     jm = jump_model(m)
 
-    
-
     if !haskey(JuMP.object_dictionary(jm), :zero_profit)
         build_constraints!(m)
     end
-
 
     #Set the default iteration limit to 10_000
     JuMP.set_attribute(jm, "cumulative_iteration_limit", 10_000)

--- a/src/production.jl
+++ b/src/production.jl
@@ -121,7 +121,7 @@ function Production(
     @assert !(isnothing(input)  && !isnothing(output)) "Production block for $(sector) has a 0 quantity in input but not output."
 
     if isnothing(input) && isnothing(output)
-        return Production(sector, netput_dict, nothing, nothing)
+        return Production(sector, netput_dict, nothing, nothing, Dict())
     end
 
 
@@ -134,11 +134,21 @@ function Production(
 
     #Store sectors by commodity
     M = model(sector) 
-    for (C,_)∈netput_dict
+    tax_dict = Dict{Consumer, Vector{Netput}}()
+    for (C,netputs)∈netput_dict
         push!(M.commodities[C], sector)
+        for n∈netputs
+            tax = taxes(n)
+            for t∈tax
+                if !haskey(tax_dict, tax_agent(t))
+                    tax_dict[tax_agent(t)] = []
+                end
+                push!(tax_dict[tax_agent(t)], n)
+            end
+        end
     end
 
-    return Production(sector, netput_dict, input, output)
+    return Production(sector, netput_dict, input, output, tax_dict)
 end
 
 #####################

--- a/src/structs.jl
+++ b/src/structs.jl
@@ -589,8 +589,9 @@ struct ScalarDemand
 
             if isa(demand, ScalarEndowment)
                 if !(haskey(M.endowments, demand.commodity))
-                    M.endowments[demand.commodity] = [consumer]
-                else
+                    M.endowments[demand.commodity] = []
+                end
+                if consumer ∉ M.endowments[demand.commodity]
                     push!(M.endowments[demand.commodity], consumer)
                 end
             end


### PR DESCRIPTION
When a model has a large number of consumers the creation of the constraints started to take a long time as we were looping over mostly empty lists. This creates a few new struct fields to store only the non-zero information. 

This _drastically_ improves performance. Before these changes building the WiNDC household model took longer than 20 minutes. Now it is 15 seconds. 