### PR TITLE
Export equilibrium condition functions

### DIFF
--- a/src/MPSGE.jl
+++ b/src/MPSGE.jl
@@ -59,7 +59,8 @@ export  @sector,    @sectors,
         @final_demand, @endowment
 
 #Building
-export  compensated_demand, tau, demand, endowment
+export  compensated_demand, tau, final_demand, endowment,
+        zero_profit, market_clearance, income_balance
 
 #Reporting
 export generate_report, solve!

--- a/src/MPSGE.jl
+++ b/src/MPSGE.jl
@@ -59,7 +59,7 @@ export  @sector,    @sectors,
         @final_demand, @endowment
 
 #Building
-export  compensated_demand, tau, final_demand, endowment,
+export  compensated_demand, tau, demand, endowment,
         zero_profit, market_clearance, income_balance
 
 #Reporting


### PR DESCRIPTION
Another tiny PR. I think the three equilibrium condition eqautions are useful and cool user-facing functions. So we should add them. 
I also wanted to change the name of the exported 'demand' function, which prints the associated equations for Consumer commodity demands to "final_demand". I briefly and unsuccessfully tried but didn't figure that out.
@mitchphillipson , if you agree that's appropriate, wanna do it?